### PR TITLE
chore: add 0.0.623-beta release notes

### DIFF
--- a/more/release-notes.mdx
+++ b/more/release-notes.mdx
@@ -14,11 +14,12 @@ Literal AI cloud is currently compatible with:
 * [TypeScript SDK](/typescript-client/development) version `0.0.503` and above.
 </Note>
 
-# 0.0.623-beta (September 2nd, 2024)
+# 0.0.623-beta (September 16th, 2024)
 
 ### New features
 * Introduced "Run Experiment" feature on datasets
 * Enabled custom prompt for LLM-as-a-Judge evaluators
+* Enabled structured output in Playground and in prompts
 * Added Total Cost chart to dashboard (input + output tokens)
 
 ### Improvements

--- a/more/release-notes.mdx
+++ b/more/release-notes.mdx
@@ -14,6 +14,29 @@ Literal AI cloud is currently compatible with:
 * [TypeScript SDK](/typescript-client/development) version `0.0.503` and above.
 </Note>
 
+# 0.0.623-beta (September 2nd, 2024)
+
+### New features
+* Introduced "Run Experiment" feature on datasets
+* Enabled custom prompt for LLM-as-a-Judge evaluators
+* Added Total Cost chart to dashboard (input + output tokens)
+
+### Improvements
+* Dataset table was enhanced with a side-panel Item View
+* Prompt Playground - Added keyboard shortcuts
+* Added ability to navigate from Generation to its root Run
+* Improved Step query efficiency for token count and environment filters
+* Improved queries for retrieving steps and threads
+* Optimized score management for faster edits and fewer queries
+* Enhanced worker performance with multi-threaded asynchronous step ingestion
+
+### Bug fixes
+* Prompt Playground:
+  * Fixed template messages editing issues
+  * Improved scroll behavior for streamed LLM generation
+* Enabled Google as a Provider in Playground
+* Updated prompt cache invalidation strategy
+
 # 0.0.621-beta (September 2nd, 2024)
 
 ### New features

--- a/typescript-client/development/changelog.mdx
+++ b/typescript-client/development/changelog.mdx
@@ -2,6 +2,12 @@
 title: Changelog
 ---
 
+# `0.0.516`
+
+### Bug fixes
+
+Made third-party dependencies optional when importing Literal AI client.
+
 # `0.0.515`
 
 ### Improvements

--- a/typescript-client/development/changelog.mdx
+++ b/typescript-client/development/changelog.mdx
@@ -2,11 +2,17 @@
 title: Changelog
 ---
 
-# `0.0.516`
+# `0.0.517` (September 16th, 2024)
+
+### Improvements
+
+* Added link to prompt as URL in the `get_prompt` API
+* Introduced decorators with `metadata`, `tags` and `stepid` fields
+* Adjusted integrations to account for `metadata` and `tags` logging
 
 ### Bug fixes
 
-Made third-party dependencies optional when importing Literal AI client.
+* Made third-party dependencies optional when importing Literal AI client.
 
 # `0.0.515`
 


### PR DESCRIPTION
### 0.0.623-beta release notes

![image](https://github.com/user-attachments/assets/cf751b22-42ec-4575-beb6-237961ac67af)

No Python SDK change

TypeScript SDK changelog:
![image](https://github.com/user-attachments/assets/bfade471-ef35-4eff-a573-7dfb341ab051)
